### PR TITLE
Workaround for issue 1328.

### DIFF
--- a/css/openseadragon.css
+++ b/css/openseadragon.css
@@ -2,3 +2,8 @@
   height: 640px;
   background-color: #000;
 }
+
+/* images display very small. workaround is to set the container at 100% width */
+.field-formatter-openseadragon-image .field-type-image__item {
+  width: 100%;
+}


### PR DESCRIPTION
Workaround for issue 1328. Setting width of seadragon's container so images will display full-width.

**GitHub Issue**: https://github.com/Islandora/documentation/issues/1328

# What does this Pull Request do?

Workaround for Open Seadragon's image viewer being very skinny.

# What's new?

.field-formatter-openseadragon-image .field-type-image__item {
  width: 100%;
}

Sets the width of the container element for Open Seadragon image viewers to 100% so that the viewer will display at the full page width.

This is very specific and shouldn't affect the display of other image fields.

# How should this be tested?

Attach image (jpg/png) media to item, see skinny viewer. Apply PR, clear cache, see viewer stretch the width of the page.

Side effect: Smaller images may stretch out to fit the width of the viewer and gain artifacts.

# Interested parties
@Islandora/8-x-committers
