### PR TITLE
Make path to openseadragon images protocol relative

### DIFF
--- a/openseadragon.module
+++ b/openseadragon.module
@@ -106,7 +106,7 @@ function template_preprocess_openseadragon_formatter(&$variables) {
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
       'options' => [
         'id' => $openseadragon_viewer_id,
-        'prefixUrl' => file_create_url("{$base_library_path}/openseadragon/images/"),
+        'prefixUrl' => file_url_transform_relative(file_create_url("{$base_library_path}/openseadragon/images/")),
         'tileSources' => $tile_sources,
       ] + $viewer_settings,
     ];


### PR DESCRIPTION
**GitHub Issue**: Islandora/documentation#1504

# What does this Pull Request do?

We encountered mixed content warnings in the browser console as OS on an HTTPS site was requesting its navigation button images via HTTP even with X-Forwarded-Proto configured. Even though it's due to be removed (https://www.drupal.org/project/drupal/issues/2669074 ) `file_url_transform_relative()` fixes the issue.

# What's new?
Wrap `file_create_url()` with `file_url_transform_relative()`.

# How should this be tested?
Visit a Repository Item page on a site served by https and observe mixed content warnings in browser console. Apply patch. Reload page and observe no mixed content warnings.

# Interested parties
@Islandora/8-x-committers
