### PR TITLE
Cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,16 @@ Drupal 8 FieldFormatter to display an image or generic file using a IIIF Image s
 
 * [drupal/libraries](https://www.drupal.org/project/libraries)
 * [drupal/token](https://www.drupal.org/project/token)
-* [OpenSeadragon library](https://github.com/openseadragon/openseadragon)
 
 ## Installation
 
-As a Drupal module, this module can be installed via composer and enabled via Drush, like:
+This module can be installed via composer and enabled via Drush, like:
 1. `composer require islandora/openseadragon:dev-8.x-1.x`
-2. download the version of OpenSeadragon that you want to install (i.e. download a release zip or tar from https://github.com/openseadragon/openseadragon/releases and unarchive it)
-3. place the version of OpenSeadragon in your drupal install in a location such as `web/sites/all/assets/vendor/openseadragon`
-4. `drush pm-en openseadragon`
+1. `drush pm-en openseadragon`
+
+Downloading/deploying the openseadragon library itself is not neccessary, as it is referenced externally via a CDN.
 
 If you are using the [islandora-playbook](https://github.com/Islandora-Devops/islandora-playbook), there is an [Ansible role](https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon) already built for installing OpenSeadragon.
-
 
 ## Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
       }
   ],
   "require": {
-    "drupal/libraries": "dev-3.x",
     "drupal/token": "^1.3",
     "npm-asset/openseadragon": "^2.4"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,16 @@
   "support": {
     "issues": "https://github.com/Islandora/documentation/issues"
   },
+  "repositories": [
+      {
+          "type": "composer",
+          "url": "https://asset-packagist.org"
+      }
+  ],
   "require": {
     "drupal/libraries": "dev-3.x",
-    "drupal/token": "^1.3"
+    "drupal/token": "^1.3",
+    "npm-asset/openseadragon": "^2.4"
   },
   "authors": [
     {
@@ -30,5 +37,13 @@
       "email": "jwhiklo@gmail.com",
       "role": "Maintainer"
     }
-  ]
+  ],
+  "extra": {
+      "installer-types": [
+          "npm-asset"
+      ],
+      "installer-paths": {
+          "web/libraries/{$name}": ["type:npm-asset"]
+      }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,9 @@
   "support": {
     "issues": "https://github.com/Islandora/documentation/issues"
   },
-  "repositories": [
-      {
-          "type": "composer",
-          "url": "https://asset-packagist.org"
-      }
-  ],
   "require": {
-    "drupal/token": "^1.3",
-    "npm-asset/openseadragon": "^2.4"
+    "drupal/libraries": "dev-3.x",
+    "drupal/token": "^1.3"
   },
   "authors": [
     {
@@ -36,13 +30,5 @@
       "email": "jwhiklo@gmail.com",
       "role": "Maintainer"
     }
-  ],
-  "extra": {
-      "installer-types": [
-          "npm-asset"
-      ],
-      "installer-paths": {
-          "web/libraries/{$name}": ["type:npm-asset"]
-      }
-  }
+  ]
 }

--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -6,6 +6,17 @@ init:
     component:
       css/openseadragon.css: {}
   dependencies:
-      - core/jquery
-      - core/jquery.once
-      - core/drupalSettings
+    - core/jquery
+    - core/jquery.once
+    - core/drupalSettings
+    - openseadragon/openseadragon
+
+openseadragon:
+  remote: https://openseadragon.github.io
+  version: 2.4.2 
+  license:
+    name: New BSD
+    url: https://openseadragon.github.io/license/
+    gpl-compatible: true
+  js:
+    https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/openseadragon.min.js { type: external, minified: true }

--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -19,4 +19,4 @@ openseadragon:
     url: https://openseadragon.github.io/license/
     gpl-compatible: true
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/openseadragon.min.js { type: external, minified: true }
+    https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/openseadragon.min.js: { type: external, minified: true }

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -20,13 +20,12 @@ function openseadragon_libraries_info() {
     'download url' => 'https://github.com/openseadragon/openseadragon/master/zipball',
     'version arguments' => [
       'file' => 'openseadragon.js',
-      // //! openseadragon 2.2.1.
       'pattern' => '@openseadragon ([0-9\.-]+)@',
       'lines' => 1,
       'columns' => 50,
     ],
     'versions' => [
-      '2.2.1' => [
+      '2.4.2' => [
         'files' => [
           'js' => [
             'openseadragon.js',
@@ -68,9 +67,6 @@ function template_preprocess_openseadragon_formatter(&$variables) {
   $config = \Drupal::service('openseadragon.config');
   $fileinfo_service = \Drupal::service('openseadragon.fileinfo');
 
-  // TODO: Once Libraries API is finished find a function for this.
-  $base_library_path = 'sites/all/assets/vendor';
-
   $classes_array = ['openseadragon-viewer'];
   $viewer_settings = $config->getSettings(TRUE);
   $iiif_address = $config->getIiifAddress();
@@ -106,7 +102,7 @@ function template_preprocess_openseadragon_formatter(&$variables) {
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
       'options' => [
         'id' => $openseadragon_viewer_id,
-        'prefixUrl' => file_create_url("{$base_library_path}/openseadragon/images/"),
+        'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/'
         'tileSources' => $tile_sources,
       ] + $viewer_settings,
     ];
@@ -151,7 +147,7 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
       'options' => [
         'id' => $openseadragon_viewer_id,
-        'prefixUrl' => file_create_url("{$base_library_path}/openseadragon/images/"),
+        'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
         'tileSources' => $tile_sources,
       ] + $viewer_settings,
     ];

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -102,7 +102,7 @@ function template_preprocess_openseadragon_formatter(&$variables) {
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
       'options' => [
         'id' => $openseadragon_viewer_id,
-        'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/'
+        'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
         'tileSources' => $tile_sources,
       ] + $viewer_settings,
     ];


### PR DESCRIPTION
**GitHub Issue**: 
- Resolves https://github.com/Islandora/documentation/issues/1518 sorta
- And in a roundabout way, this: https://github.com/Islandora/documentation/issues/1504

# What does this Pull Request do?

Uses a CDN for the openseadragon JS and images, which simplifies deployment.  One less step to get the module up and running.

# What's new?
Changed the library definition so that it points to a CDN for openseadragon.  Plus changed the `prefixUrl` config for the JS to use the CDN as well, so the button images for the player are loaded over https.

# How should this be tested?

- Pull down this code
- Delete `web/sites/all/assets/vendor/openseadragon`
- `drush cr`
- Go visit a page with the openseadragon viewer and if you watch it with the developer console, you should see requests for the viewer and its images going to CDNJS instead of your site.

# Additional Notes:
This started out as me wanting to ship openseadragon with composer, but there's no "community way" to do that yet, and it involves a lot of consistency across root composer files for all Islandora sites using openseadragon.  You can't just do it from the module's composer.json.  So I did this.  Maybe it's useful to someone?

# Interested parties
@Islandora/8-x-committers
