### PR TITLE
Allow relative URLs when configuring an openseadragon block

### DIFF
--- a/src/IIIFManifestParser.php
+++ b/src/IIIFManifestParser.php
@@ -78,7 +78,7 @@ class IIIFManifestParser {
     }
 
     // If the URL is relative, make it absolute.
-    if (substr($manifest_url, 0, 4 ) !== "http") {
+    if (substr($manifest_url, 0, 4) !== "http") {
       $manifest_url = ltrim($manifest_url, '/');
       $manifest_url = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString() . $manifest_url;
     }

--- a/src/IIIFManifestParser.php
+++ b/src/IIIFManifestParser.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\openseadragon;
 
+use Drupal\Core\Url;
 use Drupal\Core\Utility\Token;
 use Drupal\Core\Routing\RouteMatchInterface;
 use GuzzleHttp\Client;
@@ -74,6 +75,12 @@ class IIIFManifestParser {
     $current_node = $this->routeMatch->getParameter('node');
     if ($current_node) {
       $manifest_url = $this->token->replace($manifest_url, ['node' => $current_node]);
+    }
+
+    // If the URL is relative, make it absolute.
+    if (substr($manifest_url, 0, 4 ) !== "http") {
+      $manifest_url = ltrim($manifest_url, '/');
+      $manifest_url = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString() . $manifest_url;
     }
 
     try {

--- a/src/Plugin/Block/OpenseadragonBlock.php
+++ b/src/Plugin/Block/OpenseadragonBlock.php
@@ -95,7 +95,7 @@ class OpenseadragonBlock extends BlockBase implements ContainerFactoryPluginInte
     ];
     $form['iiif_manifest_url_fieldset']['iiif_manifest_url'] = [
       '#type' => 'textfield',
-      '#description' => $this->t('Absolute URL of the IIIF manifest to render.  You may use tokens to provide a pattern (e.g. "http://localhost/node/[node:nid]/manifest")'),
+      '#description' => $this->t('Relative path or URL of the IIIF manifest to render. You may use tokens to provide a pattern (e.g. "http://example.org/node/[node:nid]/manifest", or simply "node/[node:nid]/manifest" if you are referring to your own site)'),
       '#default_value' => $this->configuration['iiif_manifest_url'],
       '#maxlength' => 256,
       '#size' => 64,


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora/documentation/issues/1445

# What does this Pull Request do?

Allows a user to enter a relative URL for the IIIF manifest when placing the openseadragon block.  This makes moving the same block config from dev -> stage -> prod seamless.  Currently you have to manually edit that config every time it moves somewhere with a different hostname.

# How should this be tested?

- Make some paged content
- Pull in this PR
- `drush cr`
- Go to the paged content and make sure the block still shows up (e.g. we don't mangle the URL if it's absolute)
- Go to `admin/structure/context/openseadragon_block` and click 'Edit' on the block in the context reaction
- Set the IIIF Manifest URL to `node/[node:nid]/manifest` (e.g. chop off the base url) and click 'Update block'
- Click 'Save and continue' on the context form
- `drush cr`
- Go back to the paged content.  It should still work with the relative URL

...and now you don't have to keep reconfiguring this dang thing.

# Interested parties
@Islandora/8-x-committers
