### PR TITLE
Issue-1572: Support multiple openseadragon viewer windows

### DIFF
--- a/js/openseadragon_viewer.js
+++ b/js/openseadragon_viewer.js
@@ -18,10 +18,12 @@
      */
     Drupal.behaviors.openSeadragon = {
         attach: function(context, settings) {
-            // Use custom element #id if set.
-            base = '#' + settings.openseadragon.options.id;
-            $(base, context).once('openSeadragonViewer').each(function () {
-                  Drupal.openSeadragonViewer[base] = new Drupal.openSeadragonViewer(base, settings.openseadragon);
+            Object.keys(settings.openseadragon).forEach(function(osdViewerId) {
+              // Use custom element #id if set.
+              base = '#' + osdViewerId;
+              $(base, context).once('openSeadragonViewer').each(function () {
+                    Drupal.openSeadragonViewer[base] = new Drupal.openSeadragonViewer(base, settings.openseadragon[osdViewerId]);
+              });
             });
         },
         detach: function() {

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -101,7 +101,7 @@ function template_preprocess_openseadragon_formatter(&$variables) {
 
     $viewer_settings['sequenceMode'] = count($tile_sources) > 1 && !$viewer_settings['collectionMode'];
 
-    $variables['#attached']['drupalSettings']['openseadragon'] = [
+    $variables['#attached']['drupalSettings']['openseadragon'][$openseadragon_viewer_id] = [
       'basePath' => Url::fromUri($iiif_address),
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
       'options' => [
@@ -146,7 +146,7 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
 
   // Attach the viewer, using the image urls obtained from the manifest.
   if (!is_null($iiif_address) && !empty($iiif_address) && !empty($tile_sources)) {
-    $variables['#attached']['drupalSettings']['openseadragon'] = [
+    $variables['#attached']['drupalSettings']['openseadragon'][$openseadragon_viewer_id] = [
       'basePath' => Url::fromUri($iiif_address),
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
       'options' => [


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1572

# What does this Pull Request do?

Adds viewer ID key to openseadragon JS settings allowing us to have multiple open seadragon viewers on the same page.

# What's new?

* Changes the attached drupal settings for openseadragon from a single object to a dictionary keyed on the open seadragon viewer window the settings will apply too. 
* Changes the openseadragon_viewer.js so that it iterates over the viewer window id => settings pair to enable the viewers.
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? Just clearing cache.

# How should this be tested?

- Create a collection of several items.
- Update the members view (`http://localhost:8000/admin/structure/views/view/members?destination=/admin/structure/views`) to use the 'Open Seadragon' view mode instead of 'Teaser'.
- Clear cache.
- View the collection. _Only one member object will have the open seadragon viewer working; the others will have big black rectangles._
- Apply the PR.
- Clear cache.
- View the collection again. _All the objects will display their own open seadragon viewer._

# Interested parties
@Islandora/8-x-committers
