### PR TITLE
Remove unused dependency on libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Drupal 8 FieldFormatter to display an image or generic file using a IIIF Image s
 
 ## Requirements
 
-* [drupal/libraries](https://www.drupal.org/project/libraries)
 * [drupal/token](https://www.drupal.org/project/token)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "issues": "https://github.com/Islandora/documentation/issues"
   },
   "require": {
-    "drupal/libraries": "dev-3.x",
     "drupal/token": "^1.3"
   },
   "authors": [

--- a/openseadragon.info.yml
+++ b/openseadragon.info.yml
@@ -4,8 +4,5 @@ description: 'A light-weight, customizable OpenSeadragon field formatter'
 package: Media
 core: 8.x
 dependencies:
-  - libraries
   - token
-library_dependencies:
-  - openseadragon
 configure: openseadragon.admin_settings

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -11,33 +11,6 @@ use Drupal\Core\Url;
 use Drupal\Component\Utility\Html;
 
 /**
- * Implements hook_libraries_info().
- */
-function openseadragon_libraries_info() {
-  $libraries['openseadragon'] = [
-    'name' => 'OpenSeadragon plugin',
-    'vendor url' => 'https://openseadragon.github.io/',
-    'download url' => 'https://github.com/openseadragon/openseadragon/master/zipball',
-    'version arguments' => [
-      'file' => 'openseadragon.js',
-      'pattern' => '@openseadragon ([0-9\.-]+)@',
-      'lines' => 1,
-      'columns' => 50,
-    ],
-    'versions' => [
-      '2.4.2' => [
-        'files' => [
-          'js' => [
-            'openseadragon.js',
-          ],
-        ],
-      ],
-    ],
-  ];
-  return $libraries;
-}
-
-/**
  * Implements hook_theme().
  */
 function openseadragon_theme() {


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1729

* Other Relevant Links (Google Groups discussion, related pull requests,
https://github.com/Islandora/openseadragon/pull/26

# What does this Pull Request do?
As part of a previous issue Openseadragon was made to pull in off of a CDN. Libraries wasn't fully ripped out and is no longer required. If we wanted to support libraries still (D9 or not) we could circle back and look at https://www.drupal.org/node/3099614.

# What's new?
Removal of a dependency that is no longer used.

# How should this be tested?
- Ingest an image with Openseadragon as the viewer
- Verify it's viewable
- Pull this code and clear the cache
- Still viewable

# Interested parties
@elizoller @dannylamb 
