### PR TITLE
Add drupal/core JS dependency for anon user view.

### DIFF
--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -8,12 +8,12 @@ init:
   dependencies:
     - core/jquery
     - core/jquery.once
+    - core/drupal
     - core/drupalSettings
     - openseadragon/openseadragon
-
 openseadragon:
   remote: https://openseadragon.github.io
-  version: 2.4.2 
+  version: 2.4.2
   license:
     name: New BSD
     url: https://openseadragon.github.io/license/


### PR DESCRIPTION
**GitHub Issue**: [OpenSeadragon viewer does not display for Anonymous on Drupal 9](https://github.com/Islandora/documentation/issues/1788)


# What does this Pull Request do?

Out of the box Drupal 9, the OpenSeadragon viewer is not shown when viewing an Image object as Anonymous.

# What's new?

Drupal 9 does not include the drupal/core JS library by default for anonymous users. This PR adds this dependency.

# How should this be tested?

From a fresh install on Drupal 9:


1. Apply the patch and clear the Drupal cache.
2. Create a Repository Object and select Image for the Model and Resource Type, and OpenSeadragon for the display hint.
3. Add a Media of type Image.
4. Log out and view the object. The OpenSeadragon viewer should appear where it did not before.

# Interested parties
Fix by @ppound 

@Islandora/8-x-committers, 
