### PR TITLE
Make path to openseadragon images protocol relative

### DIFF
--- a/openseadragon.module
+++ b/openseadragon.module
@@ -106,7 +106,7 @@ function template_preprocess_openseadragon_formatter(&$variables) {
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
       'options' => [
         'id' => $openseadragon_viewer_id,
-        'prefixUrl' => file_create_url("{$base_library_path}/openseadragon/images/"),
+        'prefixUrl' => file_url_transform_relative(file_create_url("{$base_library_path}/openseadragon/images/")),
         'tileSources' => $tile_sources,
       ] + $viewer_settings,
     ];
@@ -151,7 +151,7 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
       'options' => [
         'id' => $openseadragon_viewer_id,
-        'prefixUrl' => file_create_url("{$base_library_path}/openseadragon/images/"),
+        'prefixUrl' => file_url_transform_relative(file_create_url("{$base_library_path}/openseadragon/images/")),
         'tileSources' => $tile_sources,
       ] + $viewer_settings,
     ];


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1504

# What does this Pull Request do?

Adds the same `file_url_transform_relative()` from https://github.com/Islandora/openseadragon/pull/25 to `openseadragon_iiif_manifest_block`.

# What's new 

Wrap `file_create_url()` with `file_url_transform_relative()`.

# How should this be tested?

Visit a Repository Item page on a site served by https and observe mixed content warnings in browser console. Apply patch. Reload page and observe no mixed content warnings.

# Additional Notes:

This may be superseded by https://github.com/Islandora/openseadragon/pull/26 - but we have found it useful as a workaround for now.

# Interested parties

@Islandora/8-x-committers
