### PR TITLE
Attach the JS libraries using the preprocess and not in the template.

### DIFF
--- a/openseadragon.module
+++ b/openseadragon.module
@@ -70,7 +70,6 @@ function template_preprocess_openseadragon_formatter(&$variables) {
 
     $viewer_settings['sequenceMode'] = count($tile_sources) > 1 && !$viewer_settings['collectionMode'];
     $variables['#attached']['library'] = [
-      'openseadragon/openseadragon',
       'openseadragon/init',
     ];
     $variables['#attached']['drupalSettings']['openseadragon'][$openseadragon_viewer_id] = [
@@ -116,7 +115,6 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
   // Attach the viewer, using the image urls obtained from the manifest.
   if (!is_null($iiif_address) && !empty($iiif_address) && !empty($tile_sources)) {
     $variables['#attached']['library'] = [
-      'openseadragon/openseadragon',
       'openseadragon/init',
     ];
     $variables['#attached']['drupalSettings']['openseadragon'][$openseadragon_viewer_id] = [

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -69,7 +69,10 @@ function template_preprocess_openseadragon_formatter(&$variables) {
   if (!empty($tile_sources)) {
 
     $viewer_settings['sequenceMode'] = count($tile_sources) > 1 && !$viewer_settings['collectionMode'];
-
+    $variables['#attached']['library'] = [
+      'openseadragon/openseadragon',
+      'openseadragon/init',
+    ];
     $variables['#attached']['drupalSettings']['openseadragon'][$openseadragon_viewer_id] = [
       'basePath' => Url::fromUri($iiif_address),
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
@@ -93,9 +96,6 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
   // Load the global settings.
   $config = \Drupal::service('openseadragon.config');
 
-  // @todo Once Libraries API is finished find a function for this.
-  $base_library_path = 'sites/all/assets/vendor';
-
   // Build the gallery id.
   $openseadragon_viewer_id = Html::getUniqueId('openseadragon-viewer-iiif-manifest-block');
 
@@ -115,6 +115,10 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
 
   // Attach the viewer, using the image urls obtained from the manifest.
   if (!is_null($iiif_address) && !empty($iiif_address) && !empty($tile_sources)) {
+    $variables['#attached']['library'] = [
+      'openseadragon/openseadragon',
+      'openseadragon/init',
+    ];
     $variables['#attached']['drupalSettings']['openseadragon'][$openseadragon_viewer_id] = [
       'basePath' => Url::fromUri($iiif_address),
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],

--- a/templates/openseadragon-formatter.html.twig
+++ b/templates/openseadragon-formatter.html.twig
@@ -11,6 +11,4 @@
  * @ingroup themeable
  */
 #}
-{{ attach_library('libraries/openseadragon') }}
-{{ attach_library('openseadragon/init') }}
 <div {{ attributes }}></div>

--- a/templates/openseadragon-iiif-manifest-block.html.twig
+++ b/templates/openseadragon-iiif-manifest-block.html.twig
@@ -11,6 +11,4 @@
  * @ingroup themeable
  */
 #}
-{{ attach_library('libraries/openseadragon') }}
-{{ attach_library('openseadragon/init') }}
 <div {{ attributes }}></div>


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1975

# What does this Pull Request do?
Includes the JS libraries in the preprocess implementations as opposed to the template. This fixes a bug that can occur when viewing a object with the block being rendered where there are no tilesources.

# What's new?
Errors don't pop in the console, libraries are attached a different way.

# How should this be tested?
Can reproduce the existing bug using what's documented in https://github.com/Islandora/documentation/issues/1975.
Beyond that the OSD should behave as it did before when viewing things.

# Interested parties
@Islandora/8-x-committers
