### PR TITLE
Adding JWT token to Openseadragon requests

### DIFF
--- a/openseadragon.module
+++ b/openseadragon.module
@@ -79,6 +79,9 @@ function template_preprocess_openseadragon_formatter(&$variables) {
         'id' => $openseadragon_viewer_id,
         'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
         'tileSources' => $tile_sources,
+        'loadTilesWithAjax' => TRUE,
+        'ajaxWithCredentials' => TRUE,
+        'ajaxHeaders' => ["Authorization" => "Bearer " . \Drupal::service('jwt.authentication.jwt')->generateToken()],
       ] + $viewer_settings,
     ];
 
@@ -124,6 +127,9 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
         'id' => $openseadragon_viewer_id,
         'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
         'tileSources' => $tile_sources,
+        'loadTilesWithAjax' => TRUE,
+        'ajaxWithCredentials' => TRUE,
+        'ajaxHeaders' => ["Authorization" => "Bearer " . \Drupal::service('jwt.authentication.jwt')->generateToken()],
       ] + $viewer_settings,
     ];
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2011

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
- https://github.com/Islandora-Devops/isle-buildkit/pull/175
- https://github.com/Islandora-Devops/isle-dc/pull/202

# What does this Pull Request do?

Adds credentials to Openseadragon AJAX requests

# What's new?
Jammin' in a JWT in the preprocess hooks

# How should this be tested?

Once you pull in this PR, visit a page with the openseadragon viewer on it and check out the request in your developer console.  You should see the AJAX request from Openseadragon with an Authorization header.

![image](https://user-images.githubusercontent.com/20773151/146426013-2696f45e-3c3e-42a2-ad0b-ec5a36154fad.png)

# Interested parties
@Islandora/8-x-committers
