### PR TITLE
Add interface and use trait to make the config service a cacheable dependency

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\openseadragon;
 
+use Drupal\Core\Cache\RefinableCacheableDependencyTrait;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -11,6 +12,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package Drupal\openseadragon
  */
 class Config implements ConfigInterface {
+
+  use RefinableCacheableDependencyTrait;
 
   /**
    * The openseadragon config.
@@ -49,6 +52,7 @@ class Config implements ConfigInterface {
   public function __construct(ConfigFactoryInterface $configFactory) {
     $this->config = $configFactory->get(Config::$configName);
     $this->configFactory = $configFactory;
+    $this->addCacheableDependency($this->config);
   }
 
   /**

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -2,13 +2,15 @@
 
 namespace Drupal\openseadragon;
 
+use Drupal\Core\Cache\CacheableDependencyInterface;
+
 /**
  * Special config class.
  *
  * This class allows the default config structure to remain, this is used to
  * clean up the settings form values and remove extra unnecessary arrays.
  */
-interface ConfigInterface {
+interface ConfigInterface extends CacheableDependencyInterface {
 
   /**
    * Get the default viewer settings.


### PR DESCRIPTION
... really, just inheriting cachability from the config at which it points.

**GitHub Issue**: Somewhat auxiliary to https://github.com/Islandora/documentation/issues/2134

# What does this Pull Request do?

Views dependent on the config behind the service can more easily be given the dependency on the config. 

# What's new?

Make the `\Drupal\openseadragon\Config` service implement the `\Drupal\Core\Cache\CacheableDependencyInterface` and return appropriately.

* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Unlikely.

# How should this be tested?

Presently, has no observable outcome; however, this will allow for cached items to be appropriately invalidated when the config changes.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
