### PR TITLE
[CI] Test with php 8.1.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -4,7 +4,7 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the 7.x branch
+  # Triggers the workflow on push or pull request events but only for the 2.x branch
   push:
     branches: [ 2.x ]
   pull_request:
@@ -22,37 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["7.3", "7.4"]
-        drupal-version: ["9.3.x", "9.4.x-dev"]
+        php-versions: ["7.4", "8.0", "8.1"]
+        drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
         allowed_failure: [false]
-        mysql: ["5.7"]
-        # include experimental parts
-        include:
-          # 9.3.x on PHP 8.0
-          - drupal-version: '9.3.x'
-            php-versions: '8.0'
-            mysql: "8.0"
-            allowed_failure: true
-          # 9.3.x on PHP 8.1
-          - drupal-version: '9.3.x'
-            php-versions: '8.1'
-            mysql: "8.0"
-            allowed_failure: true
-          # 9.4.x-dev on PHP "8.0"
-          - drupal-version: '9.4.x-dev'
-            php-versions: '8.0'
-            mysql: "8.0"
-            allowed_failure: true
-          # 9.4.x-dev on PHP 8.1
-          - drupal-version: '9.4.x-dev'
-            php-versions: '8.1'
-            mysql: "8.0"
-            allowed_failure: true
-          # 10.0.x-dev on PHP 8.1
-          - drupal-version: '10.0.x-dev'
-            php-versions: '8.1'
-            mysql: "8.0"
-            allowed_failure: true
+        mysql: ["8.0"]
 
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }}
     env:

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
   "require": {
     "drupal/token": "^1.3"
   },
+  "conflict": {
+      "drupal/core": "<=8"
+  },
   "authors": [
     {
       "name": "Islandora Foundation",

--- a/openseadragon.info.yml
+++ b/openseadragon.info.yml
@@ -2,8 +2,7 @@ name: 'OpenSeadragon Viewer'
 type: module
 description: 'A light-weight, customizable OpenSeadragon field formatter'
 package: Media
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9
 dependencies:
   - token
 configure: openseadragon.admin_settings


### PR DESCRIPTION
**GitHub Issue**: none (CI)

Tests are sneakily failing (they're green but are actually broken, failing on Drupal 10.). [Recent Example](https://github.com/Islandora/openseadragon/actions/runs/2706691942). 

# What does this Pull Request do?

Updates the test matrix by 
- removing php 7.3
- adding php 8.0, 8.1
- including drupal pre-release 9.5.x-dev
- removing drupal 10 till we can expect it to pass. (at least make it installable on D10!) Failing while showing the test as green gives a false expectation that it works on Drupal 10.
- making all tests mandatory

Since we're no longer testing on it, officially deprecate Drupal 8.

# How should this be tested?

* Do tests pass? 

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora/committers 