### PR TITLE
Jquery once fix

### DIFF
--- a/js/openseadragon_viewer.js
+++ b/js/openseadragon_viewer.js
@@ -4,7 +4,7 @@
  * @file
  * Displays OpenSeadragon viewer.
  */
-(function($) {
+(function(once) {
     'use strict';
 
     /**
@@ -21,7 +21,7 @@
             Object.keys(settings.openseadragon).forEach(function(osdViewerId) {
               // Use custom element #id if set.
               base = '#' + osdViewerId;
-              $(once('openSeadragonViewer', $(base, context))).each(function () {
+              once('openSeadragonViewer', base, context).each(function () {
                     Drupal.openSeadragonViewer[base] = new Drupal.openSeadragonViewer(base, settings.openseadragon[osdViewerId]);
               });
             });

--- a/js/openseadragon_viewer.js
+++ b/js/openseadragon_viewer.js
@@ -21,7 +21,7 @@
             Object.keys(settings.openseadragon).forEach(function(osdViewerId) {
               // Use custom element #id if set.
               base = '#' + osdViewerId;
-              once('openSeadragonViewer', $(base, context)).forEach(function () {
+              $(once('openSeadragonViewer', $(base, context))).each(function () {
                     Drupal.openSeadragonViewer[base] = new Drupal.openSeadragonViewer(base, settings.openseadragon[osdViewerId]);
               });
             });

--- a/js/openseadragon_viewer.js
+++ b/js/openseadragon_viewer.js
@@ -4,7 +4,7 @@
  * @file
  * Displays OpenSeadragon viewer.
  */
-(function($, once) {
+(function(once) {
     'use strict';
 
     /**
@@ -21,16 +21,19 @@
             Object.keys(settings.openseadragon).forEach(function(osdViewerId) {
               // Use custom element #id if set.
               base = '#' + osdViewerId;
-              once('openSeadragonViewer', base, context).each(function () {
+              once('openSeadragonViewer', base, context).forEach(function () {
                     Drupal.openSeadragonViewer[base] = new Drupal.openSeadragonViewer(base, settings.openseadragon[osdViewerId]);
               });
             });
         },
-        detach: function() {
-            $(base).removeClass('openSeadragonViewer-processed');
-            $(base).removeData();
-            $(base).off();
-            delete Drupal.openSeadragonViewer[base];
+        detach: function(context, settings, trigger) {
+            Object.keys(settings.openseadragon).forEach(function(osdViewerId) {
+                // Use custom element #id if set.
+                base = '#' + osdViewerId;
+                once.remove('openSeadragonViewer', base, context).forEach(function () {
+                    delete Drupal.openSeadragonViewer[base];
+                });
+            });
         }
     };
 
@@ -122,4 +125,4 @@
         }
 
     };
-})(jQuery, once);
+})(once);

--- a/js/openseadragon_viewer.js
+++ b/js/openseadragon_viewer.js
@@ -21,7 +21,7 @@
             Object.keys(settings.openseadragon).forEach(function(osdViewerId) {
               // Use custom element #id if set.
               base = '#' + osdViewerId;
-              $(base, context).once('openSeadragonViewer').each(function () {
+              $(once('openSeadragonViewer', $(base, context))).each(function () {
                     Drupal.openSeadragonViewer[base] = new Drupal.openSeadragonViewer(base, settings.openseadragon[osdViewerId]);
               });
             });

--- a/js/openseadragon_viewer.js
+++ b/js/openseadragon_viewer.js
@@ -21,7 +21,7 @@
             Object.keys(settings.openseadragon).forEach(function(osdViewerId) {
               // Use custom element #id if set.
               base = '#' + osdViewerId;
-              $(once('openSeadragonViewer', $(base, context))).each(function () {
+              once('openSeadragonViewer', $(base, context)).forEach(function () {
                     Drupal.openSeadragonViewer[base] = new Drupal.openSeadragonViewer(base, settings.openseadragon[osdViewerId]);
               });
             });
@@ -122,4 +122,4 @@
         }
 
     };
-})(jQuery);
+})(once);

--- a/js/openseadragon_viewer.js
+++ b/js/openseadragon_viewer.js
@@ -4,7 +4,7 @@
  * @file
  * Displays OpenSeadragon viewer.
  */
-(function(once) {
+(function($, once) {
     'use strict';
 
     /**
@@ -122,4 +122,4 @@
         }
 
     };
-})(once);
+})(jQuery, once);

--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -7,8 +7,8 @@ init:
       css/openseadragon.css: {}
   dependencies:
     - core/jquery
-    - core/jquery.once
     - core/drupal
+    - core/once
     - core/drupalSettings
     - openseadragon/openseadragon
 openseadragon:

--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -6,8 +6,8 @@ init:
     component:
       css/openseadragon.css: {}
   dependencies:
-    - core/drupal
     - core/once
+    - core/drupal
     - core/drupalSettings
     - openseadragon/openseadragon
 openseadragon:

--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -6,8 +6,9 @@ init:
     component:
       css/openseadragon.css: {}
   dependencies:
-    - core/once
+    - core/jquery
     - core/drupal
+    - core/once
     - core/drupalSettings
     - openseadragon/openseadragon
 openseadragon:

--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -6,7 +6,6 @@ init:
     component:
       css/openseadragon.css: {}
   dependencies:
-    - core/jquery
     - core/drupal
     - core/once
     - core/drupalSettings

--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -6,6 +6,7 @@ init:
     component:
       css/openseadragon.css: {}
   dependencies:
+    - core/jquery
     - core/drupal
     - core/once
     - core/drupalSettings


### PR DESCRIPTION
**GitHub Issue**: (link)
https://github.com/Islandora/documentation/issues/2205

# What does this Pull Request do?
Minor adjustment to the openseadragon javascript which connects the viewer to the underlying image resource

# intended result of the PR will be and/or what problem it solves.
Prevents additional canvas elements from being shown in and below an OpenSeadragon viewer.

# Technical details and possible side effects.
unknown

# How should this be tested?
BEFORE this code is merged, it is important to find an islandora object with image media that will use the OpenSeadragon viewer -- which causes the doubled-canvas output. (See https://github.com/Islandora/documentation/issues/2205). I have found that this happens when a larger resolution service file JPG is uploaded for a Service File media.
After the code has been merged, that same object from above should only display one canvas.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
