### PR TITLE
Remove deprecated prophecy calls and MimeTypeGuesserInterface.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ["8.1"]
-        drupal-version: ["9.5.x", "10.0.x", "10.1.x-dev"]
+        drupal-version: ["9.5.x", "10.0.x", "10.1.x"]
         allowed_failure: [false]
         mysql: ["8.0"]
 

--- a/src/File/FileInformation.php
+++ b/src/File/FileInformation.php
@@ -23,7 +23,7 @@ class FileInformation implements FileInformationInterface {
   /**
    * FileInformation constructor.
    *
-   * @param \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface $mimeTypeGuesser
+   * @param \Symfony\Component\Mime\MimeTypesInterface $mimeTypeGuesser
    *   File mimetype guesser interface.
    */
   public function __construct(MimeTypesInterface $mimeTypeGuesser) {

--- a/src/File/FileInformation.php
+++ b/src/File/FileInformation.php
@@ -4,7 +4,7 @@ namespace Drupal\openseadragon\File;
 
 use Drupal\file\Entity\File;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 /**
  * Gets file information for the image to be viewed.
@@ -16,7 +16,7 @@ class FileInformation implements FileInformationInterface {
   /**
    * File MimeType Guesser to use extension to determine file type.
    *
-   * @var \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface
+   * @var \Symfony\Component\Mime\MimeTypesInterface
    */
   private $mimetypeGuesser;
 
@@ -26,7 +26,7 @@ class FileInformation implements FileInformationInterface {
    * @param \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface $mimeTypeGuesser
    *   File mimetype guesser interface.
    */
-  public function __construct(MimeTypeGuesserInterface $mimeTypeGuesser) {
+  public function __construct(MimeTypesInterface $mimeTypeGuesser) {
     $this->mimetypeGuesser = $mimeTypeGuesser;
   }
 

--- a/tests/src/Kernel/ConfigTests.php
+++ b/tests/src/Kernel/ConfigTests.php
@@ -6,7 +6,9 @@ use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\openseadragon\File\FileInformation;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 /**
  * Tests the Config class.
@@ -16,6 +18,9 @@ use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
  * @coversDefaultClass Drupal\openseadragon\File\FileInformation
  */
 class ConfigTests extends KernelTestBase {
+
+  use ProphecyTrait;
+
   /**
    * {@inheritdoc}
    */
@@ -27,14 +32,14 @@ class ConfigTests extends KernelTestBase {
   /**
    * The mimetype guesser prophecy.
    *
-   * @var Prophecy\Prophet
+   * @var \Prophecy\Prophecy\ObjectProphecy
    */
   private $mimeProphet;
 
   /**
    * The file entity prophecy.
    *
-   * @var Prophecy\Prophet
+   * @var \Prophecy\Prophecy\ObjectProphecy
    */
   private $fileProphet;
 
@@ -44,7 +49,7 @@ class ConfigTests extends KernelTestBase {
   public function setUp(): void {
     parent::setUp();
 
-    $this->mimeProphet = $this->prophesize(MimeTypeGuesserInterface::class);
+    $this->mimeProphet = $this->prophesize(MimeTypesInterface::class);
     $this->fileProphet = $this->prophesize(File::class);
   }
 

--- a/tests/src/Kernel/ConfigTests.php
+++ b/tests/src/Kernel/ConfigTests.php
@@ -7,7 +7,6 @@ use Drupal\file\Entity\File;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\openseadragon\File\FileInformation;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Mime\MimeTypesInterface;
 
 /**

--- a/tests/src/Kernel/IIIFManifestParserTest.php
+++ b/tests/src/Kernel/IIIFManifestParserTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -21,6 +22,8 @@ use Psr\Log\LoggerInterface;
  * @coversDefaultClass Drupal\openseadragon\IIIFManifestParser
  */
 class IIIFManifestParserTest extends KernelTestBase {
+
+  use ProphecyTrait;
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
**GitHub Issue**:  https://github.com/Islandora/documentation/issues/2235

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.) #49 

# What does this Pull Request do?

Removes deprecated calls to prophesize() and uses of the deprecated MimeTypeGuesser. Also declares D10 compatibility. 

# What's new?

This should make it work in Drupal 10 as it does in Drupal 9.

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Spin it up on Drupal 10 and put a valid Cantaloupe URL in the OpenSeadragon settings. Place a block and feed it a manifest (since the IIIF submodule isn't ready yet) throw a demo manifest URI in the block like https://digital.library.villanova.edu/Item/vudl:92879/Manifest . Verify it shows the content, and no messages in the logs.

# Additional Notes:

The tests ran (in a D9 environment) just fine. CI will tell us about Drupal 10. 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
