### PR TITLE
View restricted access content

### DIFF
--- a/openseadragon.module
+++ b/openseadragon.module
@@ -96,6 +96,11 @@ function template_preprocess_openseadragon_formatter(&$variables) {
         'id' => $openseadragon_viewer_id,
         'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
         'tileSources' => $tile_sources,
+
+          // for dsu-utsc
+         'loadTilesWithAjax' => TRUE,
+         'ajaxWithCredentials' => TRUE,
+         'ajaxHeaders' => ["Authorization" => "Bearer " . \Drupal::service('jwt.authentication.jwt')->generateToken(), 'token' => \Drupal::service('jwt.authentication.jwt')->generateToken() ],
       ] + $viewer_settings,
     ];
 
@@ -114,7 +119,7 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
 
   // Get the tile sources from the manifest.
   $parser = \Drupal::service('openseadragon.manifest_parser');
-  $tile_sources = $parser->getTileSources($variables['iiif_manifest_url']);
+  $tile_sources = $parser->getTileSources($variables['iiif_manifest_url'], \Drupal::service('jwt.authentication.jwt')->generateToken());
 
   if (empty($tile_sources)) {
     $cache_meta->applyTo($variables);
@@ -148,6 +153,11 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
         'id' => $openseadragon_viewer_id,
         'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
         'tileSources' => $tile_sources,
+
+        // for dsu-utsc
+        'loadTilesWithAjax' => TRUE,
+        'ajaxWithCredentials' => TRUE,
+        'ajaxHeaders' => ["Authorization" => "Bearer " . \Drupal::service('jwt.authentication.jwt')->generateToken(), 'token' => \Drupal::service('jwt.authentication.jwt')->generateToken() ],
       ] + $viewer_settings,
     ];
 

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -89,6 +89,7 @@ function template_preprocess_openseadragon_formatter(&$variables) {
     $variables['#attached']['library'] = [
       'openseadragon/init',
     ];
+    $access_token = \Drupal::service('jwt.authentication.jwt')->generateToken();
     $variables['#attached']['drupalSettings']['openseadragon'][$openseadragon_viewer_id] = [
       'basePath' => Url::fromUri($iiif_address),
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
@@ -97,10 +98,13 @@ function template_preprocess_openseadragon_formatter(&$variables) {
         'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
         'tileSources' => $tile_sources,
 
-          // for dsu-utsc
-         'loadTilesWithAjax' => TRUE,
-         'ajaxWithCredentials' => TRUE,
-         'ajaxHeaders' => ["Authorization" => "Bearer " . \Drupal::service('jwt.authentication.jwt')->generateToken(), 'token' => \Drupal::service('jwt.authentication.jwt')->generateToken() ],
+          // For dsu-utsc.
+        'loadTilesWithAjax' => TRUE,
+        'ajaxWithCredentials' => TRUE,
+        'ajaxHeaders' => [
+          "Authorization" => "Bearer " . $access_token,
+          'token' => $access_token,
+        ],
       ] + $viewer_settings,
     ];
 
@@ -116,10 +120,10 @@ function template_preprocess_openseadragon_formatter(&$variables) {
  */
 function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
   $cache_meta = CacheableMetadata::createFromRenderArray($variables);
-
+  $access_token = \Drupal::service('jwt.authentication.jwt')->generateToken();
   // Get the tile sources from the manifest.
   $parser = \Drupal::service('openseadragon.manifest_parser');
-  $tile_sources = $parser->getTileSources($variables['iiif_manifest_url'], \Drupal::service('jwt.authentication.jwt')->generateToken());
+  $tile_sources = $parser->getTileSources($variables['iiif_manifest_url'], $access_token);
 
   if (empty($tile_sources)) {
     $cache_meta->applyTo($variables);
@@ -154,10 +158,13 @@ function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
         'prefixUrl' => 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
         'tileSources' => $tile_sources,
 
-        // for dsu-utsc
+        // For dsu-utsc.
         'loadTilesWithAjax' => TRUE,
         'ajaxWithCredentials' => TRUE,
-        'ajaxHeaders' => ["Authorization" => "Bearer " . \Drupal::service('jwt.authentication.jwt')->generateToken(), 'token' => \Drupal::service('jwt.authentication.jwt')->generateToken() ],
+        'ajaxHeaders' => [
+          "Authorization" => "Bearer " . $access_token,
+          'token' => $access_token,
+        ],
       ] + $viewer_settings,
     ];
 

--- a/src/IIIFManifestParser.php
+++ b/src/IIIFManifestParser.php
@@ -68,7 +68,7 @@ class IIIFManifestParser {
    * @return array
    *   The URLs of all the tile sources in a manifest.
    */
-  public function getTileSources($manifest_url) {
+  public function getTileSources($manifest_url, $access_token=NULL) {
 
     // Try to construct the URL out of a tokenized string
     // if the node is available.
@@ -85,7 +85,12 @@ class IIIFManifestParser {
 
     try {
       // Request the manifest.
-      $manifest_response = $this->httpClient->get($manifest_url);
+      //$manifest_response = $this->httpClient->get($manifest_url);
+      $manifest_response = $this->httpClient->request('GET', $manifest_url, [
+        'headers' => [
+            'Authorization' => 'Bearer ' . $access_token,        
+        ]
+      ]);
 
       // Decode the manifest json.
       $manifest_string = (string) $manifest_response->getBody();

--- a/src/IIIFManifestParser.php
+++ b/src/IIIFManifestParser.php
@@ -64,11 +64,13 @@ class IIIFManifestParser {
    *
    * @param string $manifest_url
    *   The location of the IIIF manifest, which can include tokens.
+   * @param string $access_token
+   *   The JWT Access token.
    *
    * @return array
    *   The URLs of all the tile sources in a manifest.
    */
-  public function getTileSources($manifest_url, $access_token=NULL) {
+  public function getTileSources($manifest_url, $access_token = NULL) {
 
     // Try to construct the URL out of a tokenized string
     // if the node is available.
@@ -85,11 +87,11 @@ class IIIFManifestParser {
 
     try {
       // Request the manifest.
-      //$manifest_response = $this->httpClient->get($manifest_url);
+      // $manifest_response = $this->httpClient->get($manifest_url);
       $manifest_response = $this->httpClient->request('GET', $manifest_url, [
         'headers' => [
-            'Authorization' => 'Bearer ' . $access_token,        
-        ]
+          'Authorization' => 'Bearer ' . $access_token,
+        ],
       ]);
 
       // Decode the manifest json.


### PR DESCRIPTION
# What does this Pull Request do?

- Based on the previous PR: https://github.com/Islandora/openseadragon/pull/40
- Prevent the 403 error when OSD viewer loads an restricted image in the field formatter
- Solve the non-loading OSD multi-pages block

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

- Attach a JWT token in Rest requests to Cantaloupe 
- Attach a JWT token in GET request to `/node/nid/book-manifest` in the manifest parser if the node is restricted access.

# How should this be tested?

A description of what steps someone could take to:
- Setup isle-dc with access control with Group in [this PR](https://github.com/Islandora-Devops/islandora-starter-site/pull/100)
- Replace the openseadragon module with this branch. 
- Create a book repository item node and its children OR with sample content ingested, visit https://islandora.traefik.me/node/29


# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
