### PR TITLE
Use MimeTypeGuesserInterface.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "drupal/token": "^1.3"
   },
   "conflict": {
-      "drupal/core": "<=8"
+      "drupal/core": "<9.1"
   },
   "authors": [
     {

--- a/openseadragon.info.yml
+++ b/openseadragon.info.yml
@@ -2,7 +2,7 @@ name: 'OpenSeadragon Viewer'
 type: module
 description: 'A light-weight, customizable OpenSeadragon field formatter'
 package: Media
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9.1 || ^10
 dependencies:
   - token:token
 configure: openseadragon.admin_settings

--- a/src/File/FileInformation.php
+++ b/src/File/FileInformation.php
@@ -4,7 +4,7 @@ namespace Drupal\openseadragon\File;
 
 use Drupal\file\Entity\File;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Mime\MimeTypesInterface;
+use Symfony\Component\Mime\MimeTypeGuesserInterface;
 
 /**
  * Gets file information for the image to be viewed.
@@ -16,17 +16,17 @@ class FileInformation implements FileInformationInterface {
   /**
    * File MimeType Guesser to use extension to determine file type.
    *
-   * @var \Symfony\Component\Mime\MimeTypesInterface
+   * @var \Symfony\Component\Mime\MimeTypeGuesserInterface
    */
   private $mimetypeGuesser;
 
   /**
    * FileInformation constructor.
    *
-   * @param \Symfony\Component\Mime\MimeTypesInterface $mimeTypeGuesser
+   * @param \Symfony\Component\Mime\MimeTypeGuesserInterface $mimeTypeGuesser
    *   File mimetype guesser interface.
    */
-  public function __construct(MimeTypesInterface $mimeTypeGuesser) {
+  public function __construct(MimeTypeGuesserInterface $mimeTypeGuesser) {
     $this->mimetypeGuesser = $mimeTypeGuesser;
   }
 
@@ -51,7 +51,7 @@ class FileInformation implements FileInformationInterface {
     $mime_type = $file->getMimeType();
     if (strpos($mime_type, 'image/') === FALSE) {
       // Try a better mimetype guesser.
-      $mime_type = $this->mimetypeGuesser->guess($uri);
+      $mime_type = $this->mimetypeGuesser->guessMimeType($uri);
       if (strpos($mime_type, 'image/') === FALSE) {
         // If we still don't have an image. Exit.
         return $output;


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2235

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
Slack discussion: https://islandora.slack.com/archives/CM5PPAV28/p1689795239307959

# What does this Pull Request do?

Fixes a WSOD-causing typo(?). Use MimeTypeGuesserInterface rather than MimeTypesInterface. 

# What's new?

* Changes x feature to such that y
* Added x
* Removed y
* Does this change require documentation to be updated?
* Does this change add any new dependencies?
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?
* Could this change impact execution of existing code?

# How should this be tested?

Set up an islandora with some content that uses openseadragon.
Be on Openseadragon's 2.x branch, (HEAD, not the latest release) go to an opensedragon-y content page, and it'll whitescreen.
Pull this change, and it should behave normally again. 

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@ruebot and @Islandora/committers
