### PR TITLE
Allow OSD to show on restricted paged objects.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.1"]
-        drupal-version: ["9.5.x", "10.0.x", "10.1.x"]
+        php-versions: ["8.1", "8.2"]
+        drupal-version: ["10.0.x", "10.1.x", "10.2.x-dev"]
         allowed_failure: [false]
         mysql: ["8.0"]
 

--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -2,8 +2,8 @@ name: Mirror to Drupal.org GitLab
 
 on:
   push:
-    branches:
-      - 2.x
+    branches: [2.x]
+    tags: '*'
 
 jobs:
   build:

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
   "conflict": {
       "drupal/core": "<9.1"
   },
+  "suggest": {
+      "drupal/coi": "Some configuration fields work with Config Override Inspector."
+  },
   "authors": [
     {
       "name": "Islandora Foundation",

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -89,6 +89,7 @@ function template_preprocess_openseadragon_formatter(&$variables) {
     $variables['#attached']['library'] = [
       'openseadragon/init',
     ];
+    $access_token = \Drupal::service('jwt.authentication.jwt')->generateToken();
     $variables['#attached']['drupalSettings']['openseadragon'][$openseadragon_viewer_id] = [
       'basePath' => Url::fromUri($iiif_address),
       'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
@@ -110,11 +111,12 @@ function template_preprocess_openseadragon_formatter(&$variables) {
  * Implements template_preprocess_HOOK().
  */
 function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
+  $access_token = \Drupal::service('jwt.authentication.jwt')->generateToken();
   $cache_meta = CacheableMetadata::createFromRenderArray($variables);
 
   // Get the tile sources from the manifest.
   $parser = \Drupal::service('openseadragon.manifest_parser');
-  $tile_sources = $parser->getTileSources($variables['iiif_manifest_url']);
+  $tile_sources = $parser->getTileSources($variables['iiif_manifest_url'], $access_token);
 
   if (empty($tile_sources)) {
     $cache_meta->applyTo($variables);

--- a/src/Config.php
+++ b/src/Config.php
@@ -16,6 +16,13 @@ class Config implements ConfigInterface {
   use RefinableCacheableDependencyTrait;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * The openseadragon config.
    *
    * @var \Drupal\Core\Config\ImmutableConfig

--- a/src/Form/OpenSeadragonSettingsForm.php
+++ b/src/Form/OpenSeadragonSettingsForm.php
@@ -96,6 +96,9 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#default_value' => $this->seadragonConfig->getIiifAddress(),
         '#required' => TRUE,
         '#description' => t('Please enter the image server location without trailing slash. eg:  http://www.example.org/iiif/2.'),
+        '#config' => [
+          'key' => 'openseadragon.settings:iiif_server',
+        ],
       ],
       'manifest_view' => [
         '#type' => 'select',

--- a/src/IIIFManifestParser.php
+++ b/src/IIIFManifestParser.php
@@ -64,11 +64,13 @@ class IIIFManifestParser {
    *
    * @param string $manifest_url
    *   The location of the IIIF manifest, which can include tokens.
+   * @param string $access_token
+   *   The JWT Access token.
    *
    * @return array
    *   The URLs of all the tile sources in a manifest.
    */
-  public function getTileSources($manifest_url) {
+  public function getTileSources($manifest_url, $access_token = NULL) {
 
     // Try to construct the URL out of a tokenized string
     // if the node is available.
@@ -85,7 +87,16 @@ class IIIFManifestParser {
 
     try {
       // Request the manifest.
-      $manifest_response = $this->httpClient->get($manifest_url);
+      if (empty($access_token)) {
+        $manifest_response = $this->httpClient->get($manifest_url);
+      }
+      else {
+        $manifest_response = $this->httpClient->request('GET', $manifest_url, [
+          'headers' => [
+            'Authorization' => 'Bearer ' . $access_token,
+          ],
+        ]);
+      }
 
       // Decode the manifest json.
       $manifest_string = (string) $manifest_response->getBody();

--- a/src/IIIFManifestParser.php
+++ b/src/IIIFManifestParser.php
@@ -82,7 +82,20 @@ class IIIFManifestParser {
     // If the URL is relative, make it absolute.
     if (substr($manifest_url, 0, 4) !== "http") {
       $manifest_url = ltrim($manifest_url, '/');
-      $manifest_url = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString() . $manifest_url;
+
+      // Check if the URL starts with "/fr/" and adjust accordingly.
+      // https://redmine.library.yorku.ca/issues/3957
+      if (strpos($manifest_url, '/fr/') === 0) {
+        // If the URL starts with "/fr/", don't trim the first slash.
+        $append_slash = '';
+      }
+      else {
+        // If the URL doesn't start with "/fr/", trim the first slash.
+        $append_slash = '/';
+      }
+
+      // Construct the absolute URL.
+      $manifest_url = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString() . $append_slash . $manifest_url;
     }
 
     try {


### PR DESCRIPTION
**GitHub Issue**: Not sure if there is an actual issue for this.

* See also: [Slack conversation](https://islandora.slack.com/archives/CM5PPAV28/p1688656057468829?thread_ts=1688575922.967679&cid=CM5PPAV28)

# What does this Pull Request do?

* Alternate implementation of of #51
* This is essentially @kylehuynh205 and @dannylamb's work, I haven't done anything here other than test and package it all up.

# How should this be tested?

You'd probably need the group based access control setup.

1. Create a paged object, and put access controls on it.
2. Load of the page.
3. OSD should not display
4. Add this commit to OSD, and `drush cr`
5. Refresh the page, and you should see OSD.

# Interested parties
@seth-shaw-asu 
