### PR TITLE
PHP 8.2, fix missing property definition

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -16,6 +16,13 @@ class Config implements ConfigInterface {
   use RefinableCacheableDependencyTrait;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * The openseadragon config.
    *
    * @var \Drupal\Core\Config\ImmutableConfig


### PR DESCRIPTION
Just fixing a warning when bumping up to PHP 8.2:

> Deprecated function: Creation of dynamic property Drupal\openseadragon\Config::$configFactory is deprecated in Drupal\openseadragon\Config->__construct() (line 54 of modules/contrib/openseadragon/src/Config.php). 

<details>

<summary>Stacktrace</summary>

```
Drupal\openseadragon\Config->__construct(Object) (Line: 259)
Drupal\Component\DependencyInjection\Container->createService(Array, 'openseadragon.config') (Line: 177)
Drupal\Component\DependencyInjection\Container->get('openseadragon.config') (Line: 77)
Drupal\openseadragon\Plugin\Block\OpenseadragonBlock::create(Object, Array, 'openseadragon_block', Array) (Line: 21)
Drupal\Core\Plugin\Factory\ContainerFactory->createInstance('openseadragon_block', Array) (Line: 76)
Drupal\Component\Plugin\PluginManagerBase->createInstance('openseadragon_block', Array) (Line: 62)
Drupal\Core\Plugin\DefaultSingleLazyPluginCollection->initializePlugin('openseadragon_block') (Line: 57)
Drupal\block\BlockPluginCollection->initializePlugin('openseadragon_block') (Line: 80)
Drupal\Component\Plugin\LazyPluginCollection->get('openseadragon_block') (Line: 45)
Drupal\block\BlockPluginCollection->get('openseadragon_block') (Line: 83)
Drupal\Core\Plugin\DefaultSingleLazyPluginCollection->setConfiguration(Array) (Line: 99)
Drupal\Core\Plugin\DefaultSingleLazyPluginCollection->addInstanceId('openseadragon_block', Array) (Line: 55)
Drupal\Core\Plugin\DefaultSingleLazyPluginCollection->__construct(Object, 'openseadragon_block', Array) (Line: 34)
Drupal\block\BlockPluginCollection->__construct(Object, 'openseadragon_block', Array, 'openseadragonblock') (Line: 156)
Drupal\block\Entity\Block->getPluginCollection() (Line: 145)
Drupal\block\Entity\Block->getPlugin() (Line: 118)
Drupal\block\BlockAccessControlHandler->checkAccess(Object, 'view', Object) (Line: 105)
Drupal\Core\Entity\EntityAccessControlHandler->access(Object, 'view', Object, 1) (Line: 314)
Drupal\Core\Entity\EntityBase->access('view', NULL, 1) (Line: 63)
Drupal\block\BlockRepository->getVisibleBlocksPerRegion(Array) (Line: 137)
Drupal\block\Plugin\DisplayVariant\BlockPageVariant->build() (Line: 189)
Drupal\context\Plugin\DisplayVariant\ContextBlockPageVariant->getBuildFromBlockLayout() (Line: 139)
Drupal\context\Plugin\DisplayVariant\ContextBlockPageVariant->build() (Line: 75)
Drupal\context_groups\Plugin\DisplayVariant\ContextGroupsBlockPageVariant->build() (Line: 270)
Drupal\Core\Render\MainContent\HtmlRenderer->prepare(Array, Object, Object) (Line: 128)
Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse(Array, Object, Object) (Line: 90)
Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray(Object, 'kernel.view', Object)
call_user_func(Array, Object, 'kernel.view', Object) (Line: 111)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch(Object, 'kernel.view') (Line: 187)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 76)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 58)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 48)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 48)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 51)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 51)
Drupal\Core\StackMiddleware\StackedHttpKernel->handle(Object, 1, 1) (Line: 704)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```

</details>