### PR TITLE
Add COI integration to settings form.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
   "conflict": {
       "drupal/core": "<9.1"
   },
+  "suggest": {
+      "drupal/coi": "Some configuration fields work with Config Override Inspector."
+  },
   "authors": [
     {
       "name": "Islandora Foundation",

--- a/src/Form/OpenSeadragonSettingsForm.php
+++ b/src/Form/OpenSeadragonSettingsForm.php
@@ -96,6 +96,9 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#default_value' => $this->seadragonConfig->getIiifAddress(),
         '#required' => TRUE,
         '#description' => t('Please enter the image server location without trailing slash. eg:  http://www.example.org/iiif/2.'),
+	'#config' => [
+          'key' => 'openseadragon.settings:iiif_server',
+        ],
       ],
       'manifest_view' => [
         '#type' => 'select',

--- a/src/Form/OpenSeadragonSettingsForm.php
+++ b/src/Form/OpenSeadragonSettingsForm.php
@@ -96,7 +96,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#default_value' => $this->seadragonConfig->getIiifAddress(),
         '#required' => TRUE,
         '#description' => t('Please enter the image server location without trailing slash. eg:  http://www.example.org/iiif/2.'),
-	'#config' => [
+        '#config' => [
           'key' => 'openseadragon.settings:iiif_server',
         ],
       ],


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-Devops/islandora-starter-site/issues/112

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
* https://github.com/Islandora-Devops/islandora-starter-site/issues/17

# What does this Pull Request do?

Allows Config Override Inspector (COI) to act on the iiif server url config in openseadragon.

<img width="1048" alt="Screenshot 2023-10-24 at 9 37 28 AM" src="https://github.com/Islandora/openseadragon/assets/1943338/b40ab302-5f5a-4d82-96cd-757212202ae7">


# What's new?

* Lets COI mark this setting as overridden.
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?


* Install Openseadragon using a method that uses the settings.php file to override config - for example, the site template currently does this.
* Visit the form fields for overridden values. You will see the "saved config" value which is overridden so not actually active. You will also be able to change the "saved config" value.
* Install Config Override Inspector (coi). Before this PR, nothing happens. But with this PR, the Openseadragon settings values are marked as overridden.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
